### PR TITLE
Retire legacy Spotify scraping schedules

### DIFF
--- a/.github/workflows/recently_played.yml
+++ b/.github/workflows/recently_played.yml
@@ -2,8 +2,6 @@ name: Get Recently Played Tracks
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '13 * * * *'
 
 permissions:
   contents: write

--- a/.github/workflows/top_items.yml
+++ b/.github/workflows/top_items.yml
@@ -2,8 +2,6 @@ name: Get Top Tracks and Artists
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '20 */4 * * *'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Remove cron schedules from the legacy recently-played and top-items scrapers.
- Keep `workflow_dispatch` so the old scraper can still be run manually for audit or rollback.
- Leave existing data and job bodies untouched.

## Testing
- `ruby -e 'require \"yaml\"; ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/*.yml`
- `rg -n \"schedule:|cron:|workflow_run:\" .github/workflows -g '*.yml'` returned no matches.
- `git diff --check`

## Post-Deploy Monitoring & Validation
- **What to monitor/search**
  - Actions history for unexpected runs of `Get Recently Played Tracks` or `Get Top Tracks and Artists`.
  - Commit history for new recurring `Latest data` commits.
- **Expected healthy behavior**
  - Workflows remain manually runnable but no longer run on a cron.
- **Failure signals / rollback trigger**
  - Any automatic scraper run after merge, or missing manual dispatch controls.
  - Roll back by restoring the previous `schedule` entries.
- **Validation window & owner**
  - Window: first 24 hours after merge.
  - Owner: Sergio.